### PR TITLE
Using boolean for postfix_use_sasl_passwd_file

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -16,7 +16,7 @@
     dest: /etc/postfix/sasl_passwd
     mode: 0600
   when:
-    - postfix_use_sasl_passwd_file == "True"
+    - postfix_use_sasl_passwd_file|bool == True
   notify:
     - postmap sasl_passwd
     - enable postfix


### PR DESCRIPTION
I think is better to use a boolean for this variable. In this way it should be backward compatible for who is using a string.